### PR TITLE
ci: various fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,13 +1,21 @@
-on: [push]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
 
 name: build-and-test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   check:
     name: Build and Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: |
@@ -19,10 +27,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Neovim
-        shell: bash
-        run: |
-            wget -q https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.deb -O /tmp/nvim.deb
-            sudo dpkg -i /tmp/nvim.deb
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: nightly
 
       - name: Install plenary.nvim (for testing)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,12 @@ on:
     tags:
       - v*
 
-
 jobs:
   release-image:
     name: Release latest version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
- add dependabot for automatic action version bumps
- Use action-setup-vim to install neovim since the debian package
  doesn't exists anymore
- Use concurrency to cancel unnecessary work
- Enable CI on pull requests