### PR TITLE
fix: disable luals warnings

### DIFF
--- a/crates/vim9-gen/src/lib.rs
+++ b/crates/vim9-gen/src/lib.rs
@@ -1681,6 +1681,7 @@ mod generate_program {
 -- Ignore "value assigned to a local variable is unused" because
 --  we can't guarantee that local variables will be used by plugins
 -- luacheck: ignore 311
+--- @diagnostic disable
 
 local vim9 = require('_vim9script')
 local M = {}


### PR DESCRIPTION
Generated files should not be linted since it's not possible to fix
them.
